### PR TITLE
Expose grab method

### DIFF
--- a/dragula.js
+++ b/dragula.js
@@ -44,6 +44,7 @@ function dragula (initialContainers, options) {
     containers: o.containers,
     start: manualStart,
     end: end,
+    grab: grab,
     cancel: cancel,
     remove: remove,
     destroy: destroy,


### PR DESCRIPTION
Exposing the `grab` method allow developers to initiate a grab movement using custom logic. 

This simple change gives powerful freedom to developers in the way they want the drag and drop to operate. In my case I'm now able to add a timeout before dragging can start. Here is my process:

1. I listen to `mousedown` and `touchstart` events on elements I would like to be *draggable*
2. This events are received in a `shouldLift()` method that which start a timeout function
3. I also listen to `mouseup` and `touchend` events. These events are received in a `clearShouldLift()` method which clear the timeout
4. In the case the timeout reaches its timing before `clearShouldLift()` occurs, I fire a `.grab(event)` in the drake instance, passing along the event received from `mousedown` or `touchstart`

I find that exposing the `grab` method is a minor change increasing the opportunities on the way to use the dragula api.


```
// FYI: this code is part of an Aurelia View Model
shoudLiftTimeout = null;
shouldLift(event) {
  this.shoudLiftTimeout = setTimeout(() => {
    this.dragApi.grab(event); // dragApi is my drake instance
  }, 1500);
  return true;
}

clearShouldLift(event) {
  if(this.shoudLiftTimeout) clearTimeout(this.shoudLiftTimeout);
  return true;
}
```